### PR TITLE
fix(nestjs-logger): missmatch typings path

### DIFF
--- a/packages/nestjs-logger/package.json
+++ b/packages/nestjs-logger/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
-  "typings": "dist/types/index.d.ts",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
affects: @atlantis-lab/nestjs-logger