### PR TITLE
chore: fix build

### DIFF
--- a/packages/nestjs-aws-s3/package.json
+++ b/packages/nestjs-aws-s3/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "clean": "rm -r -f dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "yarn clean",
     "build": "tsc -p tsconfig.json",
     "prepack": "pubflow store",
     "postpack": "pubflow restore"

--- a/packages/nestjs-bus/package.json
+++ b/packages/nestjs-bus/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json"
   },
   "peerDependencies": {

--- a/packages/nestjs-logger/package.json
+++ b/packages/nestjs-logger/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json"
   },
   "peerDependencies": {

--- a/packages/nestjs-map-errors-interceptor/package.json
+++ b/packages/nestjs-map-errors-interceptor/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json"
   },
   "peerDependencies": {

--- a/packages/nestjs-signed-url/package.json
+++ b/packages/nestjs-signed-url/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "clean": "rimraf lib",
     "prepublishOnly": "yarn run build",
-    "prebuild": "rimraf lib",
     "build": "tsc -p tsconfig.json"
   },
   "peerDependencies": {

--- a/packages/nestjs-tinkoff/package.json
+++ b/packages/nestjs-tinkoff/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "clean": "rm -r -f dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "yarn clean",
     "build": "tsc -p tsconfig.json",
     "prepack": "pubflow store",
     "postpack": "pubflow restore"

--- a/packages/server-scripts/package.json
+++ b/packages/server-scripts/package.json
@@ -21,7 +21,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "prepublishOnly": "yarn run build",
-    "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {


### PR DESCRIPTION
affects: @atlantis-lab/nestjs-aws-s3, @atlantis-lab/nestjs-bus, @atlantis-lab/nestjs-logger,
@atlantis-lab/nestjs-map-errors-interceptor, @atlantis-lab/nestjs-signed-url,
@atlantis-lab/nestjs-tinkoff, @atlantis-lab/server-scripts