### PR TITLE
feat(nestjs-tinkoff): impl request verifier guard

### DIFF
--- a/packages/nestjs-tinkoff/package.json
+++ b/packages/nestjs-tinkoff/package.json
@@ -15,11 +15,12 @@
     "postpack": "pubflow restore"
   },
   "peerDependencies": {
-    "@atlantis-lab/tinkoff-api": ">=0.1.1",
-    "@nestjs/common": "^6.0.0 || ^7.0.0"
+    "@atlantis-lab/tinkoff-api": ">=0.1.5",
+    "@nestjs/common": "^6.0.0 || ^7.0.0",
+    "@nestjs/platform-express": ">=6.2.4"
   },
   "devDependencies": {
-    "@atlantis-lab/tinkoff-api": "0.1.1",
+    "@atlantis-lab/tinkoff-api": "0.1.5",
     "@monstrs/publish-flow": "0.1.3",
     "@nestjs/common": "7.3.2",
     "typescript": "4.1.2"

--- a/packages/nestjs-tinkoff/src/guards/index.ts
+++ b/packages/nestjs-tinkoff/src/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './request-verifier.guard'

--- a/packages/nestjs-tinkoff/src/guards/request-verifier.guard.ts
+++ b/packages/nestjs-tinkoff/src/guards/request-verifier.guard.ts
@@ -1,0 +1,12 @@
+import { verifyRequest }                             from '@atlantis-lab/tinkoff-api'
+
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+
+@Injectable()
+export class RequestVerifierGuard implements CanActivate {
+  public canActivate(context: ExecutionContext): boolean {
+    const { body } = context.switchToHttp().getRequest()
+    const verified = verifyRequest(body)
+    return verified
+  }
+}

--- a/packages/nestjs-tinkoff/src/index.ts
+++ b/packages/nestjs-tinkoff/src/index.ts
@@ -1,2 +1,3 @@
 export * from './tinkoff.module'
-export * from './tinkoff.service'
+export * from './services'
+export * from './guards'

--- a/packages/nestjs-tinkoff/src/services/index.ts
+++ b/packages/nestjs-tinkoff/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './tinkoff.service'

--- a/packages/nestjs-tinkoff/src/services/tinkoff.service.ts
+++ b/packages/nestjs-tinkoff/src/services/tinkoff.service.ts
@@ -2,7 +2,7 @@ import { Tinkoff, TinkoffPublicOptions } from '@atlantis-lab/tinkoff-api'
 
 import { Inject, Injectable }            from '@nestjs/common'
 
-import { TINKOFF_API_OPTIONS }           from './tinkoff.constants'
+import { TINKOFF_API_OPTIONS }           from '../tinkoff.constants'
 
 @Injectable()
 export class TinkoffService extends Tinkoff {

--- a/packages/nestjs-tinkoff/src/tinkoff.module.ts
+++ b/packages/nestjs-tinkoff/src/tinkoff.module.ts
@@ -2,8 +2,8 @@ import { TinkoffPublicOptions }  from '@atlantis-lab/tinkoff-api'
 
 import { DynamicModule, Module } from '@nestjs/common'
 
+import { TinkoffService }        from './services'
 import { TINKOFF_API_OPTIONS }   from './tinkoff.constants'
-import { TinkoffService }        from './tinkoff.service'
 
 @Module({
   providers: [TinkoffService],

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,10 +66,10 @@
     "@angular-devkit/core" "8.3.20"
     rxjs "6.4.0"
 
-"@atlantis-lab/tinkoff-api@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@atlantis-lab/tinkoff-api/-/tinkoff-api-0.1.1.tgz#bf591c4f5fcb0d18c60bffedda947c7fb43cc498"
-  integrity sha512-akwjFgx5C1TJtJADyb6y+SJJCAouFUnrxqP5RczlndmRJzBgrkKbXYrGycPlUDcBKOWcGmCYsm2aDCTvUubZ8A==
+"@atlantis-lab/tinkoff-api@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@atlantis-lab/tinkoff-api/-/tinkoff-api-0.1.5.tgz#df6f85065c2bfce80fa4146c11cf60a1b24d223a"
+  integrity sha512-HR4fz+VQYq9qPt+2aHqhSyR/sAydUStGx3voqG+PaPAz4dQu6wcWLydAXJhtGNWCCbHZZ0ugpDB8t6LbXCJhgQ==
   dependencies:
     node-fetch "2.6.1"
     rimraf "3.0.2"


### PR DESCRIPTION
affects: @atlantis-lab/nestjs-tinkoff

BREAKING CHANGE:
you should be upgrade @atlantis-lab/tinkoff-api to 0.1.5 & use @nestjs/platform-express >=6.2.4